### PR TITLE
adding a Mongo GridFS cache option

### DIFF
--- a/havarti/storage/mongostorage.py
+++ b/havarti/storage/mongostorage.py
@@ -1,0 +1,48 @@
+# Copyright 2012 Jake Basile
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flask import abort, current_app, request 
+from gridfs import GridFS, NoFile
+from werkzeug.wsgi import wrap_file
+
+cache_for=31536000
+
+def get_package_filename(package, filename):
+    return '/' + package + '/' + filename 
+
+def store_package(db, package, filename):
+    storage = GridFS(db, 'fs')
+    file = open(filename, 'r')
+    storage.put(file.read(), filename=get_package_filename(package, filename) )
+
+def retrieve_package(db, package, filename):
+    storage = GridFS(db, 'fs')
+    try:
+        fileobj = storage.get_last_version(filename=get_package_filename(package, filename))
+    except NoFile:
+         abort(404)
+
+    data = wrap_file(request.environ, fileobj, buffer_size=1024 * 256)
+    response = current_app.response_class(
+        data,
+        mimetype=fileobj.content_type,
+        direct_passthrough=True)
+    response.content_length = fileobj.length
+    response.last_modified = fileobj.upload_date
+    response.set_etag(fileobj.md5)
+    response.cache_control.max_age = cache_for
+    response.cache_control.s_max_age = cache_for
+    response.cache_control.public = True
+    response.make_conditional(request)
+    return response

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='havarti',
-    version='0.2',
+    version='0.2.1',
     description='A quaint cheese shop that plays nicely in The Cloud.',
     author='Jake Basile',
     author_email='jakebasile@me.com',
     url='https://github.com/jakebasile/havarti',
-    download_url='https://github.com/downloads/jakebasile/havarti/havarti-0.2.tar.gz',
+    download_url='https://github.com/downloads/jakebasile/havarti/havarti-0.2.1.tar.gz',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Not much more to add I've implemented a new storage engine utilizing GridFS.

It uses the existing Mongo database that has already been setup. 

I've not tried it on Heroku but, I see no reason that it should fail. 

Baring the possibility of being blocked by MongoHQ.
